### PR TITLE
feat: add forest hunt, admin rights, and version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Created by Maksim Radaev/[@vflame6](https://github.com/vflame6)
 
 `sharefinder` is a network share discovery tool that enumerates shares, permissions and files in networks and domains.
 
+Authenticated scans report the target Windows version and build. When the account has local admin rights, Sharefinder also tries to refine that into the exact product/build from the remote registry.
+
 Authenticated scans also report SMB signing status and whether the supplied credentials have local admin rights on the target.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Created by Maksim Radaev/[@vflame6](https://github.com/vflame6)
 
 `sharefinder` is a network share discovery tool that enumerates shares, permissions and files in networks and domains.
 
+Authenticated scans also report SMB signing status and whether the supplied credentials have local admin rights on the target.
+
 ## Features
 
 ![sharefinder](static/sharefinder_demo.png)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Created by Maksim Radaev/[@vflame6](https://github.com/vflame6)
 
 Main commands:
 
-- `hunt`: hunt network shares inside Active Directory domain
+- `hunt`: hunt network shares inside an Active Directory domain, or across the forest with `--forest`
 - `auth`: search for shares with specified credentials
 - `guest`: search for shares accessible with guest authentication
 - `null`: search for shares accessible by null session
@@ -67,6 +67,10 @@ Commands:
   guest [<flags>] <target>
   auth --username=USERNAME [<flags>] <target>
   hunt --username=USERNAME [<flags>] <dc>
+
+Examples:
+  sharefinder hunt -u CORP\\alice -p 'Password123!' 10.0.0.10
+  sharefinder hunt -u CORP\\alice -p 'Password123!' --forest 10.0.0.10
 ```
 
 ## Installation

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -271,7 +271,7 @@ func ExecuteAuth(s *scanner.Scanner, target, username, password, hash string, lo
 	return nil
 }
 
-func ExecuteHunt(s *scanner.Scanner, username, password, hash string, dc, resolver net.IP, kerberos bool, dcHostname string) error {
+func ExecuteHunt(s *scanner.Scanner, username, password, hash string, dc, resolver net.IP, forest, kerberos bool, dcHostname string) error {
 	var targetDomain string
 	var targetUsername string
 	var err error
@@ -316,10 +316,15 @@ func ExecuteHunt(s *scanner.Scanner, username, password, hash string, dc, resolv
 	s.Options.DomainController = dc
 	s.Options.DCHostname = dcHostname
 	s.Options.CustomResolver = resolver
+	s.Options.Forest = forest
 
 	var wg sync.WaitGroup
 
-	logger.Warnf("Starting %s domain enumeration", s.Options.Domain)
+	if s.Options.Forest {
+		logger.Warnf("Starting forest-wide enumeration from %s", s.Options.Domain)
+	} else {
+		logger.Warnf("Starting %s domain enumeration", s.Options.Domain)
+	}
 
 	// enumerate possible targets via domain controller
 	possibleTargets, err := s.RunEnumerateDomainComputers()

--- a/main.go
+++ b/main.go
@@ -51,15 +51,15 @@ var (
 
 	// auth command
 	// find authenticated shares and permissions
-	authCommand       = app.Command("auth", "authenticated module")
-	authTargetArg     = authCommand.Arg("target", "Target, IP range or filename").Required().String()
-	authUsernameFlag  = authCommand.Flag("username", "Username in format DOMAIN\\username for domain auth, and just username for local auth").Short('u').Required().String()
-	authPasswordFlag  = authCommand.Flag("password", "User's password").Short('p').String()
-	authHashFlag      = authCommand.Flag("hashes", "NTLM hash of password to authenticate").Short('H').String()
-	authLocalAuthFlag = authCommand.Flag("local-auth", "Enable local authentication, the username is passed without domain").Bool()
-	authKerberosFlag  = authCommand.Flag("kerberos", "Use Kerberos authentication").Short('k').Bool()
+	authCommand        = app.Command("auth", "authenticated module")
+	authTargetArg      = authCommand.Arg("target", "Target, IP range or filename").Required().String()
+	authUsernameFlag   = authCommand.Flag("username", "Username in format DOMAIN\\username for domain auth, and just username for local auth").Short('u').Required().String()
+	authPasswordFlag   = authCommand.Flag("password", "User's password").Short('p').String()
+	authHashFlag       = authCommand.Flag("hashes", "NTLM hash of password to authenticate").Short('H').String()
+	authLocalAuthFlag  = authCommand.Flag("local-auth", "Enable local authentication, the username is passed without domain").Bool()
+	authKerberosFlag   = authCommand.Flag("kerberos", "Use Kerberos authentication").Short('k').Bool()
 	authDcHostnameFlag = authCommand.Flag("dc-hostname", "Hostname of domain controller for Kerberos authentication").String()
-	authDcIPFlag      = authCommand.Flag("dc-ip", "IP of KDC when using Kerberos authentication").IP()
+	authDcIPFlag       = authCommand.Flag("dc-ip", "IP of KDC when using Kerberos authentication").IP()
 
 	// hunt command
 	// hunt for targets from AD and find shares and permissions
@@ -69,6 +69,7 @@ var (
 	huntPasswordFlag   = huntCommand.Flag("password", "Domain user's password").Short('p').String()
 	huntHashFlag       = huntCommand.Flag("hashes", "NTLM hash of password to authenticate").Short('H').String()
 	huntResolverFlag   = huntCommand.Flag("resolver", "Custom DNS resolver IP address").Short('r').IP()
+	huntForestFlag     = huntCommand.Flag("forest", "Search all available domains in the current forest").Default("false").Bool()
 	huntKerberosFlag   = huntCommand.Flag("kerberos", "Use Kerberos authentication").Short('k').Bool()
 	huntDcHostnameFlag = huntCommand.Flag("dc-hostname", "Hostname of domain controller for Kerberos authentication").String()
 )
@@ -137,7 +138,7 @@ func main() {
 		err = cmd.ExecuteAuth(scanner, *authTargetArg, *authUsernameFlag, *authPasswordFlag, *authHashFlag, *authLocalAuthFlag, *authKerberosFlag, *authDcHostnameFlag, *authDcIPFlag)
 	}
 	if command == huntCommand.FullCommand() {
-		err = cmd.ExecuteHunt(scanner, *huntUsernameFlag, *huntPasswordFlag, *huntHashFlag, *huntDcArg, *huntResolverFlag, *huntKerberosFlag, *huntDcHostnameFlag)
+		err = cmd.ExecuteHunt(scanner, *huntUsernameFlag, *huntPasswordFlag, *huntHashFlag, *huntDcArg, *huntResolverFlag, *huntForestFlag, *huntKerberosFlag, *huntDcHostnameFlag)
 	}
 	if err != nil {
 		logger.Fatal(err)

--- a/scanner/formatter.go
+++ b/scanner/formatter.go
@@ -16,7 +16,15 @@ var (
 )
 
 func SPrintHostInfo(host, version, hostname, domain string, signing bool) string {
-	return fmt.Sprintf("[+] %s: %s (name:%s) (domain:%s) (signing:%v)", host, version, hostname, domain, signing)
+	return SPrintHostInfoWithAdmin(host, version, hostname, domain, signing, nil)
+}
+
+func SPrintHostInfoWithAdmin(host, version, hostname, domain string, signing bool, admin *bool) string {
+	result := fmt.Sprintf("[+] %s: %s (name:%s) (domain:%s) (signing:%v)", host, version, hostname, domain, signing)
+	if admin != nil {
+		result += fmt.Sprintf(" (admin:%v)", *admin)
+	}
+	return result
 }
 
 func SprintFiles(files []File) string {

--- a/scanner/ldap.go
+++ b/scanner/ldap.go
@@ -22,6 +22,11 @@ type LDAPConnection struct {
 	gssClient  *gssapi.Client
 }
 
+type DomainPartition struct {
+	Name   string
+	BaseDN string
+}
+
 func GetBaseDN(domain string) string {
 	result := "dc="
 	dns := strings.Split(domain, ".")
@@ -237,4 +242,67 @@ func (conn *LDAPConnection) SearchComputers(baseDN string) (*ldap.SearchResult, 
 		return nil, err
 	}
 	return sr, nil
+}
+
+func (conn *LDAPConnection) SearchForestDomains() ([]DomainPartition, error) {
+	rootDSERequest := ldap.NewSearchRequest(
+		"",
+		ldap.ScopeBaseObject,
+		ldap.NeverDerefAliases,
+		1,
+		0,
+		false,
+		"(objectClass=*)",
+		[]string{"configurationNamingContext"},
+		nil,
+	)
+	rootDSEResult, err := conn.connection.Search(rootDSERequest)
+	if err != nil {
+		return nil, err
+	}
+	if len(rootDSEResult.Entries) == 0 {
+		return nil, fmt.Errorf("empty rootDSE response")
+	}
+
+	configNC := rootDSEResult.Entries[0].GetAttributeValue("configurationNamingContext")
+	if configNC == "" {
+		return nil, fmt.Errorf("configurationNamingContext not found")
+	}
+
+	searchRequest := ldap.NewSearchRequest(
+		configNC,
+		ldap.ScopeWholeSubtree,
+		ldap.NeverDerefAliases,
+		math.MaxInt32,
+		0,
+		false,
+		"(&(objectClass=crossRef)(systemFlags:1.2.840.113556.1.4.803:=2)(dnsRoot=*)(nCName=*))",
+		[]string{"dnsRoot", "nCName"},
+		nil,
+	)
+	sr, err := conn.connection.SearchWithPaging(searchRequest, math.MaxInt32)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	results := make([]DomainPartition, 0, len(sr.Entries))
+	for _, entry := range sr.Entries {
+		name := strings.ToLower(strings.TrimSpace(entry.GetAttributeValue("dnsRoot")))
+		baseDN := strings.TrimSpace(entry.GetAttributeValue("nCName"))
+		if name == "" || baseDN == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		results = append(results, DomainPartition{Name: name, BaseDN: baseDN})
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no forest domains found")
+	}
+
+	return results, nil
 }

--- a/scanner/ldap.go
+++ b/scanner/ldap.go
@@ -285,9 +285,13 @@ func (conn *LDAPConnection) SearchForestDomains() ([]DomainPartition, error) {
 		return nil, err
 	}
 
+	return extractDomainPartitions(sr.Entries)
+}
+
+func extractDomainPartitions(entries []*ldap.Entry) ([]DomainPartition, error) {
 	seen := make(map[string]struct{})
-	results := make([]DomainPartition, 0, len(sr.Entries))
-	for _, entry := range sr.Entries {
+	results := make([]DomainPartition, 0, len(entries))
+	for _, entry := range entries {
 		name := strings.ToLower(strings.TrimSpace(entry.GetAttributeValue("dnsRoot")))
 		baseDN := strings.TrimSpace(entry.GetAttributeValue("nCName"))
 		if name == "" || baseDN == "" {

--- a/scanner/ldap_test.go
+++ b/scanner/ldap_test.go
@@ -1,0 +1,80 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+func TestGetBaseDN(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		want   string
+	}{
+		{name: "single label", domain: "corp", want: "dc=corp"},
+		{name: "two labels", domain: "corp.local", want: "dc=corp,dc=local"},
+		{name: "three labels", domain: "child.corp.local", want: "dc=child,dc=corp,dc=local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetBaseDN(tt.domain); got != tt.want {
+				t.Fatalf("GetBaseDN(%q) = %q, want %q", tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractDomainPartitions(t *testing.T) {
+	entries := []*ldap.Entry{
+		{
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "dnsRoot", Values: []string{"corp.local"}},
+				{Name: "nCName", Values: []string{"DC=corp,DC=local"}},
+			},
+		},
+		{
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "dnsRoot", Values: []string{"CHILD.corp.local"}},
+				{Name: "nCName", Values: []string{"DC=child,DC=corp,DC=local"}},
+			},
+		},
+		{
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "dnsRoot", Values: []string{"corp.local"}},
+				{Name: "nCName", Values: []string{"DC=corp,DC=local"}},
+			},
+		},
+		{
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "dnsRoot", Values: []string{""}},
+				{Name: "nCName", Values: []string{"DC=ignored,DC=local"}},
+			},
+		},
+	}
+
+	got, err := extractDomainPartitions(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 partitions after filtering/dedup, got %d", len(got))
+	}
+	if got[0].Name != "corp.local" || got[0].BaseDN != "DC=corp,DC=local" {
+		t.Fatalf("unexpected first partition: %#v", got[0])
+	}
+	if got[1].Name != "child.corp.local" || got[1].BaseDN != "DC=child,DC=corp,DC=local" {
+		t.Fatalf("unexpected second partition: %#v", got[1])
+	}
+}
+
+func TestExtractDomainPartitions_NoUsableDomains(t *testing.T) {
+	_, err := extractDomainPartitions([]*ldap.Entry{{
+		Attributes: []*ldap.EntryAttribute{{Name: "dnsRoot", Values: []string{""}}},
+	}})
+	if err == nil {
+		t.Fatal("expected error when no valid forest domains are present")
+	}
+}

--- a/scanner/options.go
+++ b/scanner/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	Exclude            []string // --exclude
 	FileTXT            *os.File
 	FileXML            *os.File
+	Forest             bool   // --forest (hunt only)
 	Hash               string // --hashes
 	HashBytes          []byte // --hashes
 	Kerberos           bool

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -141,8 +141,6 @@ func (s *Scanner) RunSMBEnumeration(wg *sync.WaitGroup) {
 
 // RunEnumerateDomainComputers is executed by hunt command to get a list of hosts
 func (s *Scanner) RunEnumerateDomainComputers() ([]DNHost, error) {
-	var results []DNHost
-
 	ldapConn, err := NewLDAPConnection(
 		s.Options.DomainController,
 		s.Options.Username,
@@ -159,15 +157,25 @@ func (s *Scanner) RunEnumerateDomainComputers() ([]DNHost, error) {
 	}
 	defer ldapConn.Close()
 
-	// get a list of domain computers names
-	sr, err := ldapConn.SearchComputers(GetBaseDN(s.Options.Domain))
-	if err != nil {
-		return nil, err
-	}
-	if len(sr.Entries) == 0 {
-		return nil, errors.New("no domain computers found")
+	var searchBases []DomainPartition
+	if s.Options.Forest {
+		searchBases, err = ldapConn.SearchForestDomains()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		searchBases = []DomainPartition{{
+			Name:   strings.ToLower(s.Options.Domain),
+			BaseDN: GetBaseDN(s.Options.Domain),
+		}}
 	}
 
+	if len(searchBases) == 0 {
+		return nil, errors.New("no domain naming contexts found")
+	}
+
+	var results []DNHost
+	seenHosts := make(map[string]struct{})
 	var resolver net.IP
 	if s.Options.CustomResolver != nil {
 		resolver = s.Options.CustomResolver
@@ -175,44 +183,65 @@ func (s *Scanner) RunEnumerateDomainComputers() ([]DNHost, error) {
 		resolver = s.Options.DomainController
 	}
 
-	// test DNS resolution — skip UDP when using SOCKS proxy (SOCKS5 doesn't support UDP relay)
-	testEntry := sr.Entries[0].GetAttributeValue("dNSHostName")
 	var r *Resolver
 	if s.Options.ProxyDialer != nil {
-		// go straight to TCP DNS through the proxy
 		r = NewResolver("tcp", resolver, s.Options.Timeout, s.Options.ProxyDialer)
-		_, err = r.LookupHost(testEntry)
-		if err != nil {
-			return nil, err
-		}
 	} else {
-		// try UDP first, fall back to TCP
 		r = NewResolver("udp", resolver, s.Options.Timeout, nil)
-		_, err = r.LookupHost(testEntry)
+	}
+
+	for i, searchBase := range searchBases {
+		logger.Warnf("Enumerating domain %s", searchBase.Name)
+		sr, err := ldapConn.SearchComputers(searchBase.BaseDN)
 		if err != nil {
-			r = NewResolver("tcp", resolver, s.Options.Timeout, nil)
-			_, err = r.LookupHost(testEntry)
-			if err != nil {
-				return nil, err
+			logger.Warnf("Skipping domain %s: %v", searchBase.Name, err)
+			continue
+		}
+		if len(sr.Entries) == 0 {
+			continue
+		}
+
+		if i == 0 {
+			testEntry := sr.Entries[0].GetAttributeValue("dNSHostName")
+			if s.Options.ProxyDialer != nil {
+				_, err = r.LookupHost(testEntry)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				_, err = r.LookupHost(testEntry)
+				if err != nil {
+					r = NewResolver("tcp", resolver, s.Options.Timeout, nil)
+					_, err = r.LookupHost(testEntry)
+					if err != nil {
+						return nil, err
+					}
+				}
 			}
+		}
+
+		for _, entry := range sr.Entries {
+			hostname := entry.GetAttributeValue("dNSHostName")
+			if hostname == "" {
+				continue
+			}
+
+			possibleTarget, err := r.LookupHost(hostname)
+			if err != nil {
+				logger.Debug(err.Error())
+				continue
+			}
+			key := strings.ToLower(hostname) + "|" + possibleTarget.String()
+			if _, ok := seenHosts[key]; ok {
+				continue
+			}
+			seenHosts[key] = struct{}{}
+			results = append(results, DNHost{Hostname: hostname, IP: possibleTarget})
 		}
 	}
 
-	for _, entry := range sr.Entries {
-		hostname := entry.GetAttributeValue("dNSHostName")
-
-		// TODO: the host might have several IP addresses, so we need to process this situation somehow
-		// get target's IP address from DNS (first one)
-		possibleTarget, err := r.LookupHost(hostname)
-		if err != nil {
-			logger.Debug(err.Error())
-			continue
-		}
-		dnHost := &DNHost{
-			Hostname: hostname,
-			IP:       possibleTarget,
-		}
-		results = append(results, *dnHost)
+	if len(results) == 0 {
+		return nil, errors.New("no domain computers found")
 	}
 
 	return results, nil

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -1,0 +1,526 @@
+package scanner
+
+import (
+	"encoding/xml"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// ParseIPOrCIDR
+// ---------------------------------------------------------------------------
+
+func TestParseIPOrCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "single IPv4",
+			input: "192.168.1.1",
+			want:  []string{"192.168.1.1"},
+		},
+		{
+			name:  "CIDR /30 excludes network and broadcast",
+			input: "10.0.0.0/30",
+			want:  []string{"10.0.0.1", "10.0.0.2"},
+		},
+		{
+			name:  "CIDR /32 single host",
+			input: "10.0.0.5/32",
+			want:  nil, // /32 → IP is both network and broadcast, so excluded
+		},
+		{
+			name:  "IP range",
+			input: "192.168.1.1-5",
+			want:  []string{"192.168.1.1", "192.168.1.2", "192.168.1.3", "192.168.1.4", "192.168.1.5"},
+		},
+		{
+			name:    "invalid input",
+			input:   "not-an-ip",
+			wantErr: true,
+		},
+		{
+			name:    "invalid range end < start",
+			input:   "192.168.1.10-5",
+			wantErr: true,
+		},
+		{
+			name:  "IPv6 loopback",
+			input: "::1",
+			want:  []string{"::1"},
+		},
+		{
+			name:  "CIDR /24 count",
+			input: "10.0.0.0/24",
+			want:  nil, // just check length
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseIPOrCIDR(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Special case: /24 — just check count
+			if tt.name == "CIDR /24 count" {
+				if len(got) != 254 {
+					t.Fatalf("expected 254 hosts for /24, got %d", len(got))
+				}
+				return
+			}
+
+			if tt.want == nil {
+				if len(got) != 0 {
+					t.Fatalf("expected empty result, got %v", got)
+				}
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d IPs, got %d: %v", len(tt.want), len(got), got)
+			}
+			for i, ip := range got {
+				if ip != tt.want[i] {
+					t.Errorf("index %d: expected %s, got %s", i, tt.want[i], ip)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// incrementIP
+// ---------------------------------------------------------------------------
+
+func TestIncrementIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   net.IP
+		want string
+	}{
+		{
+			name: "simple increment",
+			ip:   net.ParseIP("192.168.1.1").To4(),
+			want: "192.168.1.2",
+		},
+		{
+			name: "octet rollover",
+			ip:   net.ParseIP("192.168.1.255").To4(),
+			want: "192.168.2.0",
+		},
+		{
+			name: "multiple rollover",
+			ip:   net.ParseIP("192.168.255.255").To4(),
+			want: "192.169.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			incrementIP(tt.ip)
+			if tt.ip.String() != tt.want {
+				t.Errorf("expected %s, got %s", tt.want, tt.ip.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isNetworkOrBroadcast
+// ---------------------------------------------------------------------------
+
+func TestIsNetworkOrBroadcast(t *testing.T) {
+	_, ipNet, _ := net.ParseCIDR("10.0.0.0/24")
+
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"network address", "10.0.0.0", true},
+		{"broadcast address", "10.0.0.255", true},
+		{"normal host", "10.0.0.1", false},
+		{"mid host", "10.0.0.128", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip).To4()
+			got := isNetworkOrBroadcast(ip, ipNet)
+			if got != tt.want {
+				t.Errorf("isNetworkOrBroadcast(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseSharefinderRun (XML)
+// ---------------------------------------------------------------------------
+
+func TestParseSharefinderRun_Valid(t *testing.T) {
+	xmlData := `<?xml version="1.0" encoding="UTF-8"?>
+<SharefinderRun version="1.0" command="sharefinder auth" time_start="2024-01-01T00:00:00Z" formatted_time_start="01/01/2024 00:00">
+  <hosts>
+    <host time="2024-01-01T00:00:01Z" ip="10.0.0.1" version="SMB2" hostname="DC01" domain="test.local" signing="true">
+      <share share_name="ADMIN$" description="Remote Admin" read_permission="true" write_permission="false">
+        <file parent="" type="dir" name="docs" size="0" last_modified="2024-01-01T00:00:00Z"/>
+      </share>
+      <share share_name="Data" description="Data share" read_permission="true" write_permission="true"/>
+    </host>
+  </hosts>
+  <time_end time="2024-01-01T00:01:00Z" formatted_time="01/01/2024 00:01"/>
+</SharefinderRun>`
+
+	result, err := ParseSharefinderRun([]byte(xmlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Version != "1.0" {
+		t.Errorf("version: expected 1.0, got %s", result.Version)
+	}
+	if len(result.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(result.Hosts))
+	}
+
+	host := result.Hosts[0]
+	if host.IP != "10.0.0.1" {
+		t.Errorf("host IP: expected 10.0.0.1, got %s", host.IP)
+	}
+	if host.Hostname != "DC01" {
+		t.Errorf("hostname: expected DC01, got %s", host.Hostname)
+	}
+	if !host.Signing {
+		t.Error("expected signing=true")
+	}
+	if len(host.Shares) != 2 {
+		t.Fatalf("expected 2 shares, got %d", len(host.Shares))
+	}
+	if host.Shares[0].ShareName != "ADMIN$" {
+		t.Errorf("share name: expected ADMIN$, got %s", host.Shares[0].ShareName)
+	}
+	if len(host.Shares[0].Files) != 1 {
+		t.Errorf("expected 1 file in first share, got %d", len(host.Shares[0].Files))
+	}
+	if !host.Shares[1].WritePermission {
+		t.Error("expected Data share to have write permission")
+	}
+}
+
+func TestParseSharefinderRun_Empty(t *testing.T) {
+	xmlData := `<?xml version="1.0" encoding="UTF-8"?>
+<SharefinderRun version="1.0" command="test" time_start="2024-01-01T00:00:00Z" formatted_time_start="01/01/2024 00:00">
+  <hosts></hosts>
+  <time_end time="2024-01-01T00:00:01Z" formatted_time="01/01/2024 00:00"/>
+</SharefinderRun>`
+
+	result, err := ParseSharefinderRun([]byte(xmlData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Hosts) != 0 {
+		t.Errorf("expected 0 hosts, got %d", len(result.Hosts))
+	}
+}
+
+func TestParseSharefinderRun_Malformed(t *testing.T) {
+	_, err := ParseSharefinderRun([]byte(`<broken xml`))
+	if err == nil {
+		t.Fatal("expected error for malformed XML")
+	}
+	// Verify it's an XML syntax error
+	if _, ok := err.(*xml.SyntaxError); !ok {
+		// xml.Unmarshal may wrap differently; just ensure non-nil error
+		t.Logf("error type: %T, message: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SPrintHostInfo
+// ---------------------------------------------------------------------------
+
+func TestSPrintHostInfo(t *testing.T) {
+	got := SPrintHostInfo("10.0.0.1", "SMB2", "DC01", "test.local", true)
+	expected := "[+] 10.0.0.1: SMB2 (name:DC01) (domain:test.local) (signing:true)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+
+	got2 := SPrintHostInfo("192.168.1.5", "SMB3", "SRV01", "corp.local", false)
+	if !strings.Contains(got2, "(signing:false)") {
+		t.Errorf("expected signing:false in output, got %q", got2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SprintHost
+// ---------------------------------------------------------------------------
+
+func TestSprintHost(t *testing.T) {
+	h := Host{
+		IP: "10.0.0.1",
+		Shares: []Share{
+			{ShareName: "ADMIN$", ReadPermission: true, WritePermission: false, Description: "Remote Admin"},
+			{ShareName: "Data", ReadPermission: true, WritePermission: true, Description: "User data"},
+			{ShareName: "IPC$", ReadPermission: false, WritePermission: false, Description: "IPC"},
+		},
+	}
+
+	t.Run("no exclude", func(t *testing.T) {
+		result := SprintHost(h, nil)
+		if !strings.Contains(result, "ADMIN$") {
+			t.Error("expected ADMIN$ in output")
+		}
+		if !strings.Contains(result, "Data") {
+			t.Error("expected Data in output")
+		}
+		if !strings.Contains(result, "IPC$") {
+			t.Error("expected IPC$ in output")
+		}
+	})
+
+	t.Run("exclude ADMIN$ and IPC$", func(t *testing.T) {
+		result := SprintHost(h, []string{"ADMIN$", "IPC$"})
+		if strings.Contains(result, "ADMIN$") {
+			t.Error("ADMIN$ should be excluded")
+		}
+		if strings.Contains(result, "IPC$") {
+			t.Error("IPC$ should be excluded")
+		}
+		if !strings.Contains(result, "Data") {
+			t.Error("Data should still be present")
+		}
+	})
+
+	t.Run("READ permission", func(t *testing.T) {
+		result := SprintHost(h, nil)
+		// ADMIN$ has READ only
+		if !strings.Contains(result, "READ") {
+			t.Error("expected READ in output")
+		}
+	})
+
+	t.Run("WRITE permission", func(t *testing.T) {
+		result := SprintHost(h, nil)
+		// Data has READ,WRITE
+		if !strings.Contains(result, "WRITE") {
+			t.Error("expected WRITE in output for Data share")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// SprintFiles
+// ---------------------------------------------------------------------------
+
+func TestSprintFiles(t *testing.T) {
+	t.Run("empty files", func(t *testing.T) {
+		got := SprintFiles(nil)
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("with files", func(t *testing.T) {
+		files := []File{
+			{
+				Type:         "dir",
+				Name:         "Documents",
+				Size:         0,
+				LastModified: time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC),
+			},
+			{
+				Type:         "file",
+				Name:         "readme.txt",
+				Size:         1024,
+				LastModified: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		}
+		got := SprintFiles(files)
+		if !strings.Contains(got, "Documents") {
+			t.Error("expected Documents in output")
+		}
+		if !strings.Contains(got, "readme.txt") {
+			t.Error("expected readme.txt in output")
+		}
+		if !strings.Contains(got, "dir") {
+			t.Error("expected dir type in output")
+		}
+		if !strings.Contains(got, "file") {
+			t.Error("expected file type in output")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NewScanner
+// ---------------------------------------------------------------------------
+
+func TestNewScanner(t *testing.T) {
+	opts := &Options{
+		Target: make(chan DNHost),
+	}
+	cmdLine := []string{"sharefinder", "auth", "-t", "10.0.0.1"}
+	ts := time.Now()
+
+	s := NewScanner(opts, cmdLine, ts, 10)
+
+	if s.Options != opts {
+		t.Error("Options not set correctly")
+	}
+	if len(s.CommandLine) != 4 {
+		t.Errorf("expected 4 command line args, got %d", len(s.CommandLine))
+	}
+	if s.Threads != 10 {
+		t.Errorf("expected 10 threads, got %d", s.Threads)
+	}
+	if !s.TimeStart.Equal(ts) {
+		t.Errorf("TimeStart mismatch")
+	}
+	if s.Stop == nil {
+		t.Error("Stop channel not initialized")
+	}
+
+	// Verify Stop channel is usable (non-nil, unbuffered)
+	go func() { s.Stop <- true }()
+	<-s.Stop
+}
+
+// ---------------------------------------------------------------------------
+// ParseTargets
+// ---------------------------------------------------------------------------
+
+func TestParseTargets_IPString(t *testing.T) {
+	opts := &Options{
+		Target: make(chan DNHost, 10),
+	}
+	s := NewScanner(opts, nil, time.Now(), 1)
+
+	err := s.ParseTargets("192.168.1.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var hosts []DNHost
+	for h := range opts.Target {
+		hosts = append(hosts, h)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	}
+	if hosts[0].IP.String() != "192.168.1.1" {
+		t.Errorf("expected 192.168.1.1, got %s", hosts[0].IP.String())
+	}
+	if hosts[0].Hostname != "" {
+		t.Errorf("expected empty hostname, got %s", hosts[0].Hostname)
+	}
+}
+
+func TestParseTargets_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "targets.txt")
+	content := "10.0.0.1\n10.0.0.2\n10.0.0.3\n"
+	if err := os.WriteFile(fpath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &Options{
+		Target: make(chan DNHost, 10),
+	}
+	s := NewScanner(opts, nil, time.Now(), 1)
+
+	err := s.ParseTargets(fpath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var hosts []DNHost
+	for h := range opts.Target {
+		hosts = append(hosts, h)
+	}
+	if len(hosts) != 3 {
+		t.Fatalf("expected 3 hosts, got %d", len(hosts))
+	}
+}
+
+func TestParseTargets_FileWithEmptyLines(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "targets.txt")
+	content := "10.0.0.1\n\n\n10.0.0.2\n  \n10.0.0.3\n"
+	if err := os.WriteFile(fpath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &Options{
+		Target: make(chan DNHost, 10),
+	}
+	s := NewScanner(opts, nil, time.Now(), 1)
+
+	err := s.ParseTargets(fpath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var hosts []DNHost
+	for h := range opts.Target {
+		hosts = append(hosts, h)
+	}
+	if len(hosts) != 3 {
+		t.Fatalf("expected 3 hosts (empty lines skipped), got %d", len(hosts))
+	}
+}
+
+func TestParseTargets_NonexistentFileInvalidIP(t *testing.T) {
+	opts := &Options{
+		Target: make(chan DNHost, 10),
+	}
+	s := NewScanner(opts, nil, time.Now(), 1)
+
+	err := s.ParseTargets("not-a-real-file-or-ip")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file + invalid IP")
+	}
+}
+
+func TestParseTargets_CIDRFromFile(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "targets.txt")
+	content := "10.0.0.0/30\n"
+	if err := os.WriteFile(fpath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &Options{
+		Target: make(chan DNHost, 10),
+	}
+	s := NewScanner(opts, nil, time.Now(), 1)
+
+	err := s.ParseTargets(fpath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var hosts []DNHost
+	for h := range opts.Target {
+		hosts = append(hosts, h)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts from /30 CIDR, got %d", len(hosts))
+	}
+}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -177,7 +177,7 @@ func TestParseSharefinderRun_Valid(t *testing.T) {
 	xmlData := `<?xml version="1.0" encoding="UTF-8"?>
 <SharefinderRun version="1.0" command="sharefinder auth" time_start="2024-01-01T00:00:00Z" formatted_time_start="01/01/2024 00:00">
   <hosts>
-    <host time="2024-01-01T00:00:01Z" ip="10.0.0.1" version="SMB2" hostname="DC01" domain="test.local" signing="true">
+    <host time="2024-01-01T00:00:01Z" ip="10.0.0.1" version="SMB2" hostname="DC01" domain="test.local" signing="true" admin="true">
       <share share_name="ADMIN$" description="Remote Admin" read_permission="true" write_permission="false">
         <file parent="" type="dir" name="docs" size="0" last_modified="2024-01-01T00:00:00Z"/>
       </share>
@@ -208,6 +208,9 @@ func TestParseSharefinderRun_Valid(t *testing.T) {
 	}
 	if !host.Signing {
 		t.Error("expected signing=true")
+	}
+	if host.Admin == nil || !*host.Admin {
+		t.Fatalf("expected admin=true, got %#v", host.Admin)
 	}
 	if len(host.Shares) != 2 {
 		t.Fatalf("expected 2 shares, got %d", len(host.Shares))
@@ -256,15 +259,25 @@ func TestParseSharefinderRun_Malformed(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSPrintHostInfo(t *testing.T) {
-	got := SPrintHostInfo("10.0.0.1", "SMB2", "DC01", "test.local", true)
-	expected := "[+] 10.0.0.1: SMB2 (name:DC01) (domain:test.local) (signing:true)"
+	adminTrue := true
+	got := SPrintHostInfoWithAdmin("10.0.0.1", "SMB2", "DC01", "test.local", true, &adminTrue)
+	expected := "[+] 10.0.0.1: SMB2 (name:DC01) (domain:test.local) (signing:true) (admin:true)"
 	if got != expected {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
 
-	got2 := SPrintHostInfo("192.168.1.5", "SMB3", "SRV01", "corp.local", false)
+	adminFalse := false
+	got2 := SPrintHostInfoWithAdmin("192.168.1.5", "SMB3", "SRV01", "corp.local", false, &adminFalse)
 	if !strings.Contains(got2, "(signing:false)") {
 		t.Errorf("expected signing:false in output, got %q", got2)
+	}
+	if !strings.Contains(got2, "(admin:false)") {
+		t.Errorf("expected admin:false in output, got %q", got2)
+	}
+
+	got3 := SPrintHostInfoWithAdmin("192.168.1.6", "SMB3", "SRV02", "corp.local", false, nil)
+	if strings.Contains(got3, "admin:") {
+		t.Errorf("did not expect admin marker when status is unknown, got %q", got3)
 	}
 }
 

--- a/scanner/smb.go
+++ b/scanner/smb.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"fmt"
 	"github.com/jfjallid/go-smb/dcerpc"
+	"github.com/jfjallid/go-smb/dcerpc/msrrp"
 	"github.com/jfjallid/go-smb/dcerpc/msscmr"
 	"github.com/jfjallid/go-smb/dcerpc/mssrvs"
 	"github.com/jfjallid/go-smb/dcerpc/smbtransport"
@@ -185,6 +186,75 @@ func (conn *Connection) CheckLocalAdmin() (bool, error) {
 	}
 
 	return false, fmt.Errorf("unexpected svcctl admin-check return code: 0x%x", res.ReturnCode)
+}
+
+func (conn *Connection) DetectWindowsVersion(fallback string) (string, error) {
+	share := "IPC$"
+	if err := conn.session.TreeConnect(share); err != nil {
+		return buildWindowsVersionString("", "", "", "", "", 0, fallback), err
+	}
+	defer conn.session.TreeDisconnect(share)
+
+	f, err := conn.session.OpenFile(share, msrrp.MSRRPPipe)
+	if err != nil {
+		return buildWindowsVersionString("", "", "", "", "", 0, fallback), err
+	}
+	defer f.CloseFile()
+
+	transport, err := smbtransport.NewSMBTransport(f)
+	if err != nil {
+		return buildWindowsVersionString("", "", "", "", "", 0, fallback), err
+	}
+	bind, err := dcerpc.Bind(transport, msrrp.MSRRPUuid, msrrp.MSRRPMajorVersion, msrrp.MSRRPMinorVersion, dcerpc.MSRPCUuidNdr)
+	if err != nil {
+		return buildWindowsVersionString("", "", "", "", "", 0, fallback), err
+	}
+
+	rpccon := msrrp.NewRPCCon(bind)
+	hklm, err := rpccon.OpenBaseKey(msrrp.HKEYLocalMachine)
+	if err != nil {
+		return buildWindowsVersionString("", "", "", "", "", 0, fallback), err
+	}
+	defer rpccon.CloseKeyHandle(hklm)
+
+	currentVersionKey, err := rpccon.OpenSubKey(hklm, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`)
+	if err != nil {
+		return buildWindowsVersionString("", "", "", "", "", 0, fallback), err
+	}
+	defer rpccon.CloseKeyHandle(currentVersionKey)
+
+	queryString := func(name string) string {
+		value, _, err := rpccon.QueryValueExt(currentVersionKey, name)
+		if err != nil {
+			return ""
+		}
+		stringValue, ok := value.(string)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(stringValue)
+	}
+	queryDWORD := func(name string) uint32 {
+		value, _, err := rpccon.QueryValueExt(currentVersionKey, name)
+		if err != nil {
+			return 0
+		}
+		dwordValue, ok := value.(uint32)
+		if !ok {
+			return 0
+		}
+		return dwordValue
+	}
+
+	return buildWindowsVersionString(
+		queryString("ProductName"),
+		queryString("DisplayVersion"),
+		queryString("ReleaseId"),
+		queryString("CurrentVersion"),
+		queryString("CurrentBuildNumber"),
+		queryDWORD("UBR"),
+		fallback,
+	), nil
 }
 
 func (conn *Connection) CheckReadAccess(share string) error {

--- a/scanner/smb.go
+++ b/scanner/smb.go
@@ -2,10 +2,11 @@ package scanner
 
 import (
 	"fmt"
-	"github.com/jfjallid/go-smb/smb"
 	"github.com/jfjallid/go-smb/dcerpc"
+	"github.com/jfjallid/go-smb/dcerpc/msscmr"
 	"github.com/jfjallid/go-smb/dcerpc/mssrvs"
 	"github.com/jfjallid/go-smb/dcerpc/smbtransport"
+	"github.com/jfjallid/go-smb/smb"
 	"github.com/jfjallid/go-smb/spnego"
 	"github.com/vflame6/sharefinder/logger"
 	"github.com/vflame6/sharefinder/utils"
@@ -127,6 +128,63 @@ func (conn *Connection) GetSharesList() ([]mssrvs.NetShare, error) {
 		return nil, err
 	}
 	return shares, nil
+}
+
+func (conn *Connection) CheckLocalAdmin() (bool, error) {
+	share := "IPC$"
+	if err := conn.session.TreeConnect(share); err != nil {
+		return false, err
+	}
+	defer conn.session.TreeDisconnect(share)
+
+	f, err := conn.session.OpenFile(share, msscmr.MSRPCSvcCtlPipe)
+	if err != nil {
+		return false, err
+	}
+	defer f.CloseFile()
+
+	transport, err := smbtransport.NewSMBTransport(f)
+	if err != nil {
+		return false, err
+	}
+	bind, err := dcerpc.Bind(transport, msscmr.MSRPCUuidSvcCtl, 2, 0, dcerpc.MSRPCUuidNdr)
+	if err != nil {
+		return false, err
+	}
+
+	rpccon := msscmr.NewRPCCon(bind)
+	req := msscmr.ROpenSCManagerWReq{
+		MachineName:   "DUMMY",
+		DatabaseName:  "ServicesActive",
+		DesiredAccess: msscmr.SCManagerCreateService,
+	}
+	reqBuf, err := req.MarshalBinary()
+	if err != nil {
+		return false, err
+	}
+
+	buffer, err := rpccon.MakeRequest(msscmr.SvcCtlROpenSCManagerW, reqBuf)
+	if err != nil {
+		return false, err
+	}
+
+	res := msscmr.ROpenSCManagerWRes{}
+	if err := res.UnmarshalBinary(buffer); err != nil {
+		return false, err
+	}
+
+	if res.ReturnCode == msscmr.ErrorSuccess {
+		rpccon.CloseServiceHandle(res.ContextHandle[:])
+		return true, nil
+	}
+	if res.ReturnCode == msscmr.ErrorAccessDenied {
+		return false, nil
+	}
+	if status, found := msscmr.ServiceResponseCodeMap[res.ReturnCode]; found {
+		return false, status
+	}
+
+	return false, fmt.Errorf("unexpected svcctl admin-check return code: 0x%x", res.ReturnCode)
 }
 
 func (conn *Connection) CheckReadAccess(share string) error {

--- a/scanner/template.html
+++ b/scanner/template.html
@@ -104,6 +104,7 @@
                 <th>Domain</th>
                 <th>Version</th>
                 <th>Signing</th>
+                <th>Admin</th>
                 <th>Shares</th>
             </tr>
             </thead>
@@ -115,6 +116,7 @@
                     <td class="text-break">{{ $host.Domain }}</td>
                     <td>{{ $host.Version }}</td>
                     <td>{{ $host.Signing }}</td>
+                    <td>{{ $host.AdminStatus }}</td>
                     <td>{{ len $host.Shares }}</td>
                 </tr>
                 {{ end }}
@@ -148,6 +150,7 @@
                         <th>Domain</th>
                         <th>Version</th>
                         <th>Signing</th>
+                        <th>Admin</th>
                         <th>Shares</th>
                     </tr>
                     </thead>
@@ -158,6 +161,7 @@
                         <td class="text-break">{{ $host.Domain }}</td>
                         <td>{{ $host.Version }}</td>
                         <td>{{ $host.Signing }}</td>
+                        <td>{{ $host.AdminStatus }}</td>
                         <td>{{ len $host.Shares }}</td>
                     </tr>
                     </tbody>

--- a/scanner/thread.go
+++ b/scanner/thread.go
@@ -47,8 +47,11 @@ func enumerateHost(host DNHost, options *Options) (Host, error) {
 	targetInfo := conn.GetTargetInfo()
 	hostResult.IP = host.IP.String()
 	hostResult.Time = time.Now()
+	hostResult.Version = "unknown"
 	if targetInfo != nil {
-		hostResult.Version = targetInfo.GuessedOSVersion
+		if targetInfo.GuessedOSVersion != "" {
+			hostResult.Version = targetInfo.GuessedOSVersion
+		}
 		hostResult.Hostname = targetInfo.NBComputerName
 		hostResult.Domain = targetInfo.DnsDomainName
 	} else {
@@ -63,6 +66,14 @@ func enumerateHost(host DNHost, options *Options) (Host, error) {
 			logger.Warnf("Failed to determine local admin rights on %s: %v", host.IP.String(), adminErr)
 		} else {
 			hostResult.Admin = &isAdmin
+			if isAdmin {
+				version, versionErr := conn.DetectWindowsVersion(hostResult.Version)
+				if versionErr != nil {
+					logger.Debugf("Failed to query registry version on %s: %v", host.IP.String(), versionErr)
+				} else {
+					hostResult.Version = version
+				}
+			}
 		}
 	}
 

--- a/scanner/thread.go
+++ b/scanner/thread.go
@@ -57,6 +57,14 @@ func enumerateHost(host DNHost, options *Options) (Host, error) {
 		hostResult.Domain = options.Domain
 	}
 	hostResult.Signing = isSigningRequired
+	if !options.NullSession {
+		isAdmin, adminErr := conn.CheckLocalAdmin()
+		if adminErr != nil {
+			logger.Warnf("Failed to determine local admin rights on %s: %v", host.IP.String(), adminErr)
+		} else {
+			hostResult.Admin = &isAdmin
+		}
+	}
 
 	// get a list of shares
 	logger.Debugf("Trying to list shares on %s (%s)", host.IP.String(), host.Hostname)
@@ -175,7 +183,7 @@ func smbThread(s <-chan bool, options *Options, wg *sync.WaitGroup) {
 			}
 
 			// format and print results on enumerated host
-			printResult := SPrintHostInfo(hostResult.IP, hostResult.Version, hostResult.Hostname, hostResult.Domain, hostResult.Signing)
+			printResult := SPrintHostInfoWithAdmin(hostResult.IP, hostResult.Version, hostResult.Hostname, hostResult.Domain, hostResult.Signing, hostResult.Admin)
 			if len(hostResult.Shares) > 0 {
 				printResult += SprintHost(hostResult, options.Exclude)
 

--- a/scanner/version.go
+++ b/scanner/version.go
@@ -1,0 +1,48 @@
+package scanner
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildWindowsVersionString(productName, displayVersion, releaseID, currentVersion, build string, ubr uint32, fallback string) string {
+	productName = strings.TrimSpace(productName)
+	displayVersion = strings.TrimSpace(displayVersion)
+	releaseID = strings.TrimSpace(releaseID)
+	currentVersion = strings.TrimSpace(currentVersion)
+	build = strings.TrimSpace(build)
+	fallback = strings.TrimSpace(fallback)
+
+	if productName == "" {
+		if fallback != "" {
+			return fallback
+		}
+		if currentVersion != "" && build != "" {
+			if ubr > 0 {
+				return fmt.Sprintf("Windows %s Build %s.%d", currentVersion, build, ubr)
+			}
+			return fmt.Sprintf("Windows %s Build %s", currentVersion, build)
+		}
+		return "unknown"
+	}
+
+	parts := []string{productName}
+	if displayVersion != "" {
+		parts = append(parts, displayVersion)
+	} else if releaseID != "" {
+		parts = append(parts, releaseID)
+	} else if currentVersion != "" && !strings.Contains(productName, currentVersion) {
+		parts = append(parts, currentVersion)
+	}
+
+	result := strings.Join(parts, " ")
+	if build != "" {
+		if ubr > 0 {
+			result += fmt.Sprintf(" Build %s.%d", build, ubr)
+		} else {
+			result += fmt.Sprintf(" Build %s", build)
+		}
+	}
+
+	return strings.TrimSpace(result)
+}

--- a/scanner/version_test.go
+++ b/scanner/version_test.go
@@ -1,0 +1,54 @@
+package scanner
+
+import "testing"
+
+func TestBuildWindowsVersionString(t *testing.T) {
+	tests := []struct {
+		name           string
+		productName    string
+		displayVersion string
+		releaseID      string
+		currentVersion string
+		build          string
+		ubr            uint32
+		fallback       string
+		want           string
+	}{
+		{
+			name:           "product display version and ubr",
+			productName:    "Windows 11 Pro",
+			displayVersion: "23H2",
+			build:          "22631",
+			ubr:            3447,
+			fallback:       "Windows NT 10.0 Build 22631",
+			want:           "Windows 11 Pro 23H2 Build 22631.3447",
+		},
+		{
+			name:        "release id fallback",
+			productName: "Windows 10 Enterprise",
+			releaseID:   "22H2",
+			build:       "19045",
+			fallback:    "Windows NT 10.0 Build 19045",
+			want:        "Windows 10 Enterprise 22H2 Build 19045",
+		},
+		{
+			name:           "registry incomplete falls back to smb guess",
+			currentVersion: "10.0",
+			fallback:       "Windows NT 10.0 Build 20348",
+			want:           "Windows NT 10.0 Build 20348",
+		},
+		{
+			name: "unknown when nothing available",
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildWindowsVersionString(tt.productName, tt.displayVersion, tt.releaseID, tt.currentVersion, tt.build, tt.ubr, tt.fallback)
+			if got != tt.want {
+				t.Fatalf("buildWindowsVersionString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/scanner/xml.go
+++ b/scanner/xml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"path/filepath"
+	"strconv"
 	"time"
 )
 
@@ -30,7 +31,15 @@ type Host struct {
 	Hostname string    `xml:"hostname,attr"`
 	Domain   string    `xml:"domain,attr"`
 	Signing  bool      `xml:"signing,attr"`
+	Admin    *bool     `xml:"admin,attr,omitempty"`
 	Shares   []Share   `xml:"share"`
+}
+
+func (h Host) AdminStatus() string {
+	if h.Admin == nil {
+		return "unknown"
+	}
+	return strconv.FormatBool(*h.Admin)
 }
 
 type Share struct {


### PR DESCRIPTION
## Summary
- add `hunt --forest` and enumerate forest domains via LDAP naming contexts before SMB scanning
- report whether authenticated credentials have local admin rights on each target
- improve Windows version reporting with cleaner fallback handling and admin-only remote-registry refinement
- document the new behavior and add focused scanner tests

## Details
This PR bundles the Sharefinder improvements requested in the current task batch:

1. Forest-wide hunt support
   - adds `--forest` to `hunt`
   - discovers forest domains from LDAP crossRef entries
   - enumerates computers per discovered domain and deduplicates hosts before SMB enumeration

2. Admin-rights detection
   - probes `svcctl` with `ROpenSCManagerW` create-service access
   - surfaces `admin:true/false` in text, XML, and HTML output

3. Windows version detection
   - keeps the existing NTLM challenge version/build fallback from `go-smb`
   - upgrades admin sessions to exact product/build strings by querying `HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion`
   - falls back cleanly to `unknown` when no version data is available

## Verification
- `go test ./...`
- `go build -o /tmp/sharefinder .`
